### PR TITLE
alpstable#368 Add missing export comments:

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -54,6 +54,8 @@ issues:
       linters:
         - goimports
         - revive
+  exclude:
+    - ST1000 # Requiring package comments interferes with copyright notice.
   exclude-use-default: false
 
 linters-settings:
@@ -61,8 +63,13 @@ linters-settings:
     ignore-names:
       - wg # wg is a standard variable name for "sync.WaitGroup"
   revive:
-    ignore-generated-header: true
     severity: warning
     rules:
+      - name: empty-lines
+      - name: line-length-limit
+        severity: error
+        arguments: [120]
+      - name: import-shadowing
+      - name: unnecessary-stmt
       - name: exported
         arguments: [ "checkPrivateReceivers", "sayRepetitiveInsteadOfStutters" ]

--- a/http.go
+++ b/http.go
@@ -244,13 +244,13 @@ type Current struct {
 	Database string         // Name of the database for storage.
 }
 
-// HTTPIteratorService is a service that will iterate over the requests defiend
+// HTTPIteratorService is a service that will iterate over the requests defined
 // for the HTTPService and return the response from each request.
 type HTTPIteratorService struct {
 	svc *HTTPService
 
-	// Current is the most recent response from the iterator. This is
-	// blocked by the "Next" method.
+	// Current is the most recent response from the iterator. This value is
+	// set and blocked by the "Next" method, updating with each iteration.
 	Current *Current
 
 	currentChan chan *Current

--- a/http.go
+++ b/http.go
@@ -44,6 +44,9 @@ type Client interface {
 	Do(*http.Request) (*http.Response, error)
 }
 
+// HTTPService is used process response data from requests sent to an HTTP
+// client. "Processing" includes upserting data into a database, or concurrently
+// iterating over the response data using a "Next" pattern.
 type HTTPService struct {
 	client Client
 	svc    *Service
@@ -60,6 +63,7 @@ type HTTPService struct {
 	upsertWriters []proto.UpsertWriter
 }
 
+// NewHTTPService will create a new HTTPService.
 func NewHTTPService(svc *Service) *HTTPService {
 	httpSvc := &HTTPService{svc: svc}
 	httpSvc.Iterator = NewHTTPIteratorService(httpSvc)
@@ -70,8 +74,8 @@ func NewHTTPService(svc *Service) *HTTPService {
 
 // RateLimiter sets the optional rate limiter for the service. A rate limiter
 // will limit the request to a set of bursts per period, avoiding 429 errors.
-func (svc *HTTPService) RateLimiter(rate *rate.Limiter) *HTTPService {
-	svc.rlimiter = rate
+func (svc *HTTPService) RateLimiter(rlimiter *rate.Limiter) *HTTPService {
+	svc.rlimiter = rlimiter
 
 	return svc
 }
@@ -104,10 +108,10 @@ func (svc *HTTPService) UpsertWriters(w ...proto.UpsertWriter) *HTTPService {
 
 // isDecodeTypeJSON will check if the provided "accept" struct is typed for
 // decoding into JSON.
-func isDecodeTypeJSON(accept accept.Accept) bool {
-	return accept.Typ == "application" &&
-		(accept.Subtype == "json" || accept.Subtype == "*") ||
-		accept.Typ == "*" && accept.Subtype == "*"
+func isDecodeTypeJSON(acceptHeader accept.Accept) bool {
+	return acceptHeader.Typ == "application" &&
+		(acceptHeader.Subtype == "json" || acceptHeader.Subtype == "*") ||
+		acceptHeader.Typ == "*" && acceptHeader.Subtype == "*"
 }
 
 // bestFitDecodeType will parse the provided Accept(-Charset|-Encoding|-Language)
@@ -121,8 +125,8 @@ func isDecodeTypeJSON(accept accept.Accept) bool {
 func bestFitDecodeType(header string) proto.DecodeType {
 	decodeType := proto.DecodeTypeUnknown
 
-	for _, accept := range accept.ParseAcceptHeader(header) {
-		if isDecodeTypeJSON(accept) {
+	for _, acceptHeader := range accept.ParseAcceptHeader(header) {
+		if isDecodeTypeJSON(acceptHeader) {
 			decodeType = proto.DecodeTypeJSON
 
 			break
@@ -194,7 +198,6 @@ func (svc *HTTPService) Upsert(ctx context.Context) error {
 
 	// Reset the iterator.
 	svc.Iterator = NewHTTPIteratorService(svc)
-	defer svc.Iterator.Close()
 
 	// Create a channel to send requests to the worker.
 	upsertWorkerJobs := make(chan upsertWorkerJob, reqCount)
@@ -224,6 +227,11 @@ func (svc *HTTPService) Upsert(ctx context.Context) error {
 		return fmt.Errorf("error in upsert worker: %w", err)
 	}
 
+	// Close the iterator.
+	if err := svc.Iterator.Close(); err != nil {
+		return fmt.Errorf("failed to close iterator: %w", err)
+	}
+
 	return nil
 }
 
@@ -236,14 +244,17 @@ type Current struct {
 	Database string         // Name of the database for storage.
 }
 
+// HTTPIteratorService is a service that will iterate over the requests defiend
+// for the HTTPService and return the response from each request.
 type HTTPIteratorService struct {
 	svc *HTTPService
 
+	// Current is the most recent response from the iterator. This is
+	// blocked by the "Next" method.
 	Current *Current
 
 	currentChan chan *Current
-
-	errCh chan error
+	errCh       chan error
 
 	// closemu prevents the iterator from closing while there is an active
 	// streaming  result. It is held for read during non-close operations
@@ -255,6 +266,7 @@ type HTTPIteratorService struct {
 	lasterr error
 }
 
+// NewHTTPIteratorService will return a new HTTPIteratorService.
 func NewHTTPIteratorService(svc *HTTPService) *HTTPIteratorService {
 	iter := &HTTPIteratorService{svc: svc, errCh: make(chan error, 1)}
 

--- a/proto/decode.go
+++ b/proto/decode.go
@@ -16,6 +16,13 @@ import (
 
 var ErrUnsupportedDecodeType = fmt.Errorf("unsupported decode type")
 
+type DecodeType int32
+
+const (
+	DecodeTypeUnknown DecodeType = iota
+	DecodeTypeJSON
+)
+
 func decodeJSON(data []byte) (*structpb.ListValue, error) {
 	// If there is no data, return an empty list.
 	if len(data) == 0 {

--- a/proto/storage.go
+++ b/proto/storage.go
@@ -11,13 +11,6 @@ import (
 	"context"
 )
 
-type DecodeType int32
-
-const (
-	DecodeTypeUnknown DecodeType = iota
-	DecodeTypeJSON
-)
-
 type UpsertWriter interface {
 	// Upsert will use an UpsertRequest to upsert a new or existing
 	// object into the storage backend.

--- a/service.go
+++ b/service.go
@@ -14,12 +14,18 @@ import (
 	"github.com/alpstable/gidari/proto"
 )
 
+// Service is the main service for Gidari. It is responsible for providing the
+// services for transporting and processing data.
 type Service struct {
+	// HTTP is used for transporting and processing HTTP requests and
+	// responses.
 	HTTP *HTTPService
 }
 
+// ServiceOption is a function for configuring a Service.
 type ServiceOption func(*Service)
 
+// NewService will create a new Service.
 func NewService(ctx context.Context, opts ...ServiceOption) (*Service, error) {
 	svc := &Service{}
 	for _, opt := range opts {


### PR DESCRIPTION
Resolves #368 

This PR adds missing comments to exportable API (other than in the "proto" package which should be renamed). It also includes extra revive linters and ignores ST1000 errors which require package-level descriptions.