### PR TITLE
Update add-license.sh

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -5,6 +5,7 @@
 // You may obtain a copy of the License at
 //
 //	http://www.apache.org/licenses/LICENSE-2.0
+
 package gidari
 
 import (

--- a/decode_test.go
+++ b/decode_test.go
@@ -5,6 +5,7 @@
 // You may obtain a copy of the License at
 //
 //	http://www.apache.org/licenses/LICENSE-2.0
+
 package gidari
 
 import (

--- a/doc.go
+++ b/doc.go
@@ -4,5 +4,5 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//    http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 package gidari

--- a/doc.go
+++ b/doc.go
@@ -1,0 +1,8 @@
+// Copyright 2023 The Gidari Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+package gidari

--- a/doc.go
+++ b/doc.go
@@ -5,4 +5,7 @@
 // You may obtain a copy of the License at
 //
 //	http://www.apache.org/licenses/LICENSE-2.0
+
+// Package gidari provides a "web-to-storage" API for batch querying
+// web APIs and persisting the resulting data.
 package gidari

--- a/http.go
+++ b/http.go
@@ -5,6 +5,7 @@
 // You may obtain a copy of the License at
 //
 //	http://www.apache.org/licenses/LICENSE-2.0
+
 package gidari
 
 import (

--- a/mock_test.go
+++ b/mock_test.go
@@ -5,6 +5,7 @@
 // You may obtain a copy of the License at
 //
 //	http://www.apache.org/licenses/LICENSE-2.0
+
 package gidari
 
 import (

--- a/scripts/add-license.sh
+++ b/scripts/add-license.sh
@@ -16,13 +16,7 @@ LICENSE_TEMPLATE=$(cat <<EOF
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//    http://www.apache.org/licenses/LICENSE-2.0
-EOF
-)
-
-# NEWLINE is added in all files except doc.go.
-NEWLINE=$(cat <<EOF
-//
+//	http://www.apache.org/licenses/LICENSE-2.0
 EOF
 )
 
@@ -30,7 +24,7 @@ EOF
 for file in $(find . -name "*.go" -type f); do
     	# skip files in the EXCLUDE_LIST
     	if [[ " ${EXCLUDE_LIST[@]} " =~ " ${file} " ]]; then
-		continue
+		    continue
     	fi
 
       # If the file starts with "// Copied from" then we don't want to prepend
@@ -45,7 +39,8 @@ for file in $(find . -name "*.go" -type f); do
     	if [[ "${file}" == ./doc.go ]]; then
           printf "%s\n" "${LICENSE_TEMPLATE}" | cat - "${file}" > /tmp/out
         else
-          printf "%s\n%s\n" "${LICENSE_TEMPLATE}" "${NEWLINE}" | cat - "${file}" > /tmp/out
+          # Adding newline for other files
+          printf "%s\n\n" "${LICENSE_TEMPLATE}" | cat - "${file}" > /tmp/out
       fi
     	mv /tmp/out "${file}"
 

--- a/scripts/add-license.sh
+++ b/scripts/add-license.sh
@@ -20,6 +20,12 @@ LICENSE_TEMPLATE=$(cat <<EOF
 EOF
 )
 
+# NEWLINE is added in all files except doc.go.
+NEWLINE=$(cat <<EOF
+//
+EOF
+)
+
 # append all *.go in this repository with the LICENSE_TEMPLATE
 for file in $(find . -name "*.go" -type f); do
     	# skip files in the EXCLUDE_LIST
@@ -28,20 +34,26 @@ for file in $(find . -name "*.go" -type f); do
     	fi
 
     	# skip files that already have the LICENSE_TEMPLATE
-    	if grep -q "Copyright $YEAR The Gidari Authors." "${file}"; then
-		continue
-    	fi
+#    	if grep -q "Copyright $YEAR The Gidari Authors." "${file}"; then
+#		continue
+#    	fi
 
-	# If the file starts with "// Copied from" then we don't want to prepend
-	# the license.
-	if grep -q "^// Copied from" "${file}"; then
-		continue
-	fi
+      # If the file starts with "// Copied from" then we don't want to prepend
+      # the license.
+      if grep -q "^// Copied from" "${file}"; then
+        continue
+      fi
+
+      sed -i '/^package/,$!d' "${file}"
 
     	# prepend the LICENSE_TEMPLATE to the file
-    	echo "${LICENSE_TEMPLATE}" | cat - "${file}" > /tmp/out && mv /tmp/out "${file}"
+    	if [[ "${file}" == ./doc.go ]]; then
+          printf "%s\n" "${LICENSE_TEMPLATE}" | cat - "${file}" > /tmp/out
+        else
+          printf "%s\n%s\n" "${LICENSE_TEMPLATE}" "${NEWLINE}" | cat - "${file}" > /tmp/out
+      fi
+    	mv /tmp/out "${file}"
 
-	echo "${LICENSE_TEMPLATE}" | cat - "${file}" > /tmp/out && mv /tmp/out "${file}"
 done
 
 

--- a/scripts/add-license.sh
+++ b/scripts/add-license.sh
@@ -16,7 +16,7 @@ LICENSE_TEMPLATE=$(cat <<EOF
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//	http://www.apache.org/licenses/LICENSE-2.0
+//    http://www.apache.org/licenses/LICENSE-2.0
 EOF
 )
 
@@ -24,26 +24,22 @@ EOF
 for file in $(find . -name "*.go" -type f); do
     	# skip files in the EXCLUDE_LIST
     	if [[ " ${EXCLUDE_LIST[@]} " =~ " ${file} " ]]; then
-		    continue
+		continue
     	fi
 
-      # If the file starts with "// Copied from" then we don't want to prepend
-      # the license.
-      if grep -q "^// Copied from" "${file}"; then
-        continue
-      fi
+    	# skip files that already have the LICENSE_TEMPLATE
+    	if grep -q "Copyright $YEAR The Gidari Authors." "${file}"; then
+		continue
+    	fi
 
-      sed -i '/^package/,$!d' "${file}"
+	# If the file starts with "// Copied from" then we don't want to prepend
+	# the license.
+	if grep -q "^// Copied from" "${file}"; then
+		continue
+	fi
 
     	# prepend the LICENSE_TEMPLATE to the file
-    	if [[ "${file}" == ./doc.go ]]; then
-          printf "%s\n" "${LICENSE_TEMPLATE}" | cat - "${file}" > /tmp/out
-        else
-          # Adding newline for other files
-          printf "%s\n\n" "${LICENSE_TEMPLATE}" | cat - "${file}" > /tmp/out
-      fi
-    	mv /tmp/out "${file}"
-
+    	printf "%s\n\n" "${LICENSE_TEMPLATE}" | cat - "${file}" > /tmp/out && mv /tmp/out "${file}"
 done
 
 

--- a/scripts/add-license.sh
+++ b/scripts/add-license.sh
@@ -33,11 +33,6 @@ for file in $(find . -name "*.go" -type f); do
 		continue
     	fi
 
-    	# skip files that already have the LICENSE_TEMPLATE
-#    	if grep -q "Copyright $YEAR The Gidari Authors." "${file}"; then
-#		continue
-#    	fi
-
       # If the file starts with "// Copied from" then we don't want to prepend
       # the license.
       if grep -q "^// Copied from" "${file}"; then

--- a/service.go
+++ b/service.go
@@ -5,6 +5,7 @@
 // You may obtain a copy of the License at
 //
 //	http://www.apache.org/licenses/LICENSE-2.0
+
 package gidari
 
 import (

--- a/version/version.go
+++ b/version/version.go
@@ -5,6 +5,7 @@
 // You may obtain a copy of the License at
 //
 //	http://www.apache.org/licenses/LICENSE-2.0
+
 package version
 
 // Version is the version of the Gidari library.


### PR DESCRIPTION
This PR does the following:
- Update `add-license.sh`
- Only for `doc.go`, append LICENSE only
- Other go files, append a newline after license

Resolves #365 

