### PR TITLE
alpstable#400 update decode pipeline

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -20,9 +20,9 @@ import (
 // supported.
 var ErrUnsupportedDecodeType = fmt.Errorf("unsupported decode type")
 
-// ErrUnsupportedProtoType is returned when the provided proto type is not
+// ErrUnsupportedProtobufType is returned when the provided proto type is not
 // supported.
-var ErrUnsupportedProtoType = fmt.Errorf("unsupported proto type")
+var ErrUnsupportedProtobufType = fmt.Errorf("unsupported proto type")
 
 // DecodeType is an enum that represents the type of data that is being decoded.
 type DecodeType int32
@@ -42,7 +42,7 @@ func addValue(list *structpb.ListValue, val *structpb.Value) error {
 	case *structpb.Value_ListValue:
 		list.Values = append(list.Values, val.GetListValue().Values...)
 	default:
-		return fmt.Errorf("%w: %T", ErrUnsupportedProtoType, val.Kind)
+		return fmt.Errorf("%w: %T", ErrUnsupportedProtobufType, val.Kind)
 	}
 
 	return nil

--- a/decode_test.go
+++ b/decode_test.go
@@ -9,8 +9,11 @@
 package gidari
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
+	"io"
+	"net/http"
 	"testing"
 
 	"google.golang.org/protobuf/proto"
@@ -70,15 +73,25 @@ func TestDecode(t *testing.T) {
 		t.Run(tcase.name, func(t *testing.T) {
 			t.Parallel()
 
-			// Then we call the DecodeUpsertRequest function.
-			list, err := Decode(tcase.dataType, tcase.data)
-			if !errors.Is(err, tcase.err) {
-				t.Fatalf("unexpected error: %v", err)
+			var decFunc DecodeFunc
+
+			switch tcase.dataType {
+			case DecodeTypeJSON:
+				decFunc = decodeFuncJSON(&http.Response{
+					Body:          io.NopCloser(bytes.NewReader(tcase.data)),
+					ContentLength: int64(len(tcase.data)),
+				})
+			case DecodeTypeUnknown:
+				fallthrough
+			default:
+				t.Fatalf("unsupported decode type: %v", tcase.dataType)
 			}
 
-			// Then we check the result.
-			if list == nil {
-				t.Fatalf("unexpected nil list")
+			// Then we call the DecodeUpsertRequest function.
+			list := &structpb.ListValue{}
+			err := decFunc(list)
+			if !errors.Is(err, tcase.err) {
+				t.Fatalf("unexpected error: %v", err)
 			}
 
 			// Convert the expected result into a list.
@@ -104,12 +117,17 @@ func BenchmarkDecodeUpsertRequest(b *testing.B) {
 
 	data = append(data, []byte(`"foo1000": "bar1000"}`)...)
 
+	httpResponse := &http.Response{
+		Body:          io.NopCloser(bytes.NewReader(data)),
+		ContentLength: int64(len(data)),
+	}
+
 	// Run the benchmark.
 	b.ResetTimer()
 	b.ReportAllocs()
 
 	for i := 0; i < b.N; i++ {
-		_, err := Decode(DecodeTypeJSON, data)
+		err := decodeFuncJSON(httpResponse)(&structpb.ListValue{})
 		if err != nil {
 			b.Fatalf("unexpected error: %v", err)
 		}

--- a/decode_test.go
+++ b/decode_test.go
@@ -117,20 +117,18 @@ func BenchmarkDecodeUpsertRequest(b *testing.B) {
 
 	data = append(data, []byte(`"foo1000": "bar1000"}`)...)
 
-	httpResponse := func() *http.Response {
-		return &http.Response{
-			Body:          io.NopCloser(bytes.NewReader(data)),
-			ContentLength: int64(len(data)),
-		}
-	}
-
 	// Run the benchmark.
 	b.ResetTimer()
 	b.ReportAllocs()
 
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
-			err := decodeFuncJSON(httpResponse())(&structpb.ListValue{})
+			httpResp := &http.Response{
+				Body:          io.NopCloser(bytes.NewReader(data)),
+				ContentLength: int64(len(data)),
+			}
+
+			err := decodeFuncJSON(httpResp)(&structpb.ListValue{})
 			if err != nil {
 				b.Fatalf("unexpected error: %v", err)
 			}

--- a/decode_test.go
+++ b/decode_test.go
@@ -128,10 +128,12 @@ func BenchmarkDecodeUpsertRequest(b *testing.B) {
 	b.ResetTimer()
 	b.ReportAllocs()
 
-	for i := 0; i < b.N; i++ {
-		err := decodeFuncJSON(httpResponse())(&structpb.ListValue{})
-		if err != nil {
-			b.Fatalf("unexpected error: %v", err)
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			err := decodeFuncJSON(httpResponse())(&structpb.ListValue{})
+			if err != nil {
+				b.Fatalf("unexpected error: %v", err)
+			}
 		}
-	}
+	})
 }

--- a/decode_test.go
+++ b/decode_test.go
@@ -117,9 +117,11 @@ func BenchmarkDecodeUpsertRequest(b *testing.B) {
 
 	data = append(data, []byte(`"foo1000": "bar1000"}`)...)
 
-	httpResponse := &http.Response{
-		Body:          io.NopCloser(bytes.NewReader(data)),
-		ContentLength: int64(len(data)),
+	httpResponse := func() *http.Response {
+		return &http.Response{
+			Body:          io.NopCloser(bytes.NewReader(data)),
+			ContentLength: int64(len(data)),
+		}
 	}
 
 	// Run the benchmark.
@@ -127,7 +129,7 @@ func BenchmarkDecodeUpsertRequest(b *testing.B) {
 	b.ReportAllocs()
 
 	for i := 0; i < b.N; i++ {
-		err := decodeFuncJSON(httpResponse)(&structpb.ListValue{})
+		err := decodeFuncJSON(httpResponse())(&structpb.ListValue{})
 		if err != nil {
 			b.Fatalf("unexpected error: %v", err)
 		}

--- a/service.go
+++ b/service.go
@@ -44,9 +44,8 @@ type ListWriter interface {
 }
 
 type listWriterJob struct {
-	dataType DecodeType
-	data     []byte
-	writer   ListWriter
+	decFunc DecodeFunc
+	writer  ListWriter
 }
 
 type listWriterConfig struct {
@@ -64,9 +63,8 @@ func writeList(ctx context.Context, job *listWriterJob) <-chan error {
 	errs := make(chan error, 1)
 
 	go func() {
-		// Decode the data into a structpb.ListValue.
-		list, err := Decode(job.dataType, job.data)
-		if err != nil {
+		list := &structpb.ListValue{}
+		if err := job.decFunc(list); err != nil {
 			errs <- err
 
 			return


### PR DESCRIPTION
Resolves #400 

This update removed the "Decode" function from the exported API in favor of a functional pattern for decoding based on the application/content-type. The new method for decoding an HTTP response body was given a minor optimization:

Before:
```
goos: darwin
goarch: arm64
pkg: github.com/alpstable/gidari
BenchmarkDecodeUpsertRequest-10             1203            927933 ns/op          314197 B/op      10059 allocs/op
```

After:
```
goos: darwin
goarch: arm64
pkg: github.com/alpstable/gidari
BenchmarkDecodeUpsertRequest-10             5685            219681 ns/op          378087 B/op      10070 allocs/op
```