### PR TITLE
alpstable#406 support multi-writer requests

### DIFF
--- a/examples/csvpb/main.go
+++ b/examples/csvpb/main.go
@@ -47,8 +47,8 @@ func main() {
 	housReq, _ := http.NewRequest(http.MethodGet, api+"/houses/10", nil)      // House Baelish
 
 	// Wrap the HTTP Requests in the gidalri.HTTPRequest type.
-	charReqWrapper := gidari.NewHTTPRequest(charReq, gidari.WithWriter(listWriter))
-	housReqWrapper := gidari.NewHTTPRequest(housReq, gidari.WithWriter(listWriter))
+	charReqWrapper := gidari.NewHTTPRequest(charReq, gidari.WithWriters(listWriter))
+	housReqWrapper := gidari.NewHTTPRequest(housReq, gidari.WithWriters(listWriter))
 
 	svc.HTTP.Requests(charReqWrapper, housReqWrapper)
 

--- a/examples/mongopb/main.go
+++ b/examples/mongopb/main.go
@@ -62,8 +62,8 @@ func main() {
 	housReq, _ := http.NewRequest(http.MethodGet, api+"/houses", nil)
 
 	// Wrap the HTTP Requests in the gidalri.HTTPRequest type.
-	charReqWrapper := gidari.NewHTTPRequest(charReq, gidari.WithWriter(bookWriter))
-	housReqWrapper := gidari.NewHTTPRequest(housReq, gidari.WithWriter(charWriter))
+	charReqWrapper := gidari.NewHTTPRequest(charReq, gidari.WithWriters(bookWriter))
+	housReqWrapper := gidari.NewHTTPRequest(housReq, gidari.WithWriters(charWriter))
 
 	svc.HTTP.Requests(charReqWrapper, housReqWrapper)
 

--- a/gidari_example_test.go
+++ b/gidari_example_test.go
@@ -111,8 +111,8 @@ func ExampleHTTPService_Upsert() {
 	w := &ExampleWriter{}
 
 	// Wrap the HTTP Requests in the gidalri.HTTPRequest type.
-	charReqWrapper := gidari.NewHTTPRequest(charReq, gidari.WithWriter(w))
-	housReqWrapper := gidari.NewHTTPRequest(housReq, gidari.WithWriter(w))
+	charReqWrapper := gidari.NewHTTPRequest(charReq, gidari.WithWriters(w))
+	housReqWrapper := gidari.NewHTTPRequest(housReq, gidari.WithWriters(w))
 
 	// Add the wrapped HTTP requests to the HTTP Service.
 	svc.HTTP.Requests(charReqWrapper, housReqWrapper)

--- a/http_test.go
+++ b/http_test.go
@@ -264,20 +264,22 @@ func TestIterator(t *testing.T) {
 				// We need to validate various operation for
 				// the upsert storage.
 				for _, req := range tcase.svc.HTTP.requests {
-					mockStorage, ok := req.writer.(*mockUpsertWriter)
-					if !ok {
-						t.Errorf("expected mock storage, got %T", req.writer)
-					}
+					for _, w := range req.writers {
+						stg, ok := w.(*mockUpsertWriter)
+						if !ok {
+							t.Errorf("expected mock storage, got %T", w)
+						}
 
-					// The number of upserts should be equal to the
-					// expected number of upserts. Note that there
-					// can be less requests than upserts, for
-					// example a timeseries request could be broken
-					// into multiple flattened requests for upsert.
-					if mockStorage.count != tcase.expectedNumberOfUpsertsPerStorage {
-						t.Errorf("expected %d upserts, got %d",
-							tcase.expectedNumberOfUpsertsPerStorage,
-							mockStorage.count)
+						// The number of upserts should be equal to the
+						// expected number of upserts. Note that there
+						// can be less requests than upserts, for
+						// example a timeseries request could be broken
+						// into multiple flattened requests for upsert.
+						if stg.count != tcase.expectedNumberOfUpsertsPerStorage {
+							t.Errorf("expected %d upserts, got %d",
+								tcase.expectedNumberOfUpsertsPerStorage,
+								stg.count)
+						}
 					}
 				}
 			})

--- a/mock_test.go
+++ b/mock_test.go
@@ -51,8 +51,8 @@ func newHTTPRequests(volume int) []*Request {
 	for i := 0; i < volume; i++ {
 		req, _ := http.NewRequest(http.MethodGet, fmt.Sprintf("http://example%d", i), nil)
 		requests[i] = &Request{
-			http:   req,
-			writer: writer,
+			http:    req,
+			writers: []ListWriter{writer},
 		}
 	}
 


### PR DESCRIPTION
Resolves #406 

This PR introduced a breaking change to update "WithWriter" to "WithWriters", allowing a gidari Request to accept multiple writers per HTTP round trip. This will allow for more efficient post-fetch data processing.

