### PR TITLE
alpstable#405 rename Upsert to Store

### DIFF
--- a/examples/csvpb/main.go
+++ b/examples/csvpb/main.go
@@ -57,8 +57,8 @@ func main() {
 	requestPerSecond := 5
 	svc.HTTP.RateLimiter(rate.NewLimiter(rate.Every(1*time.Second), requestPerSecond))
 
-	// Use Upsert to make requests and in our case write response data to stdout in CSV format.
-	if err := svc.HTTP.Upsert(ctx); err != nil {
+	// Write the response body to the CSV file.
+	if err := svc.HTTP.Store(ctx); err != nil {
 		log.Fatalf("failed to upsert HTTP responses: %v", err)
 	}
 

--- a/examples/mongopb/main.go
+++ b/examples/mongopb/main.go
@@ -72,9 +72,8 @@ func main() {
 	requestPerSecond := 5
 	svc.HTTP.RateLimiter(rate.NewLimiter(rate.Every(1*time.Second), requestPerSecond))
 
-	// Use Upsert to make requests and in our case write response data to
-	// the MongoDB collectionsMongoDB collections.
-	if err := svc.HTTP.Upsert(ctx); err != nil {
+	// Upser the data to the MongoDB collection.
+	if err := svc.HTTP.Store(ctx); err != nil {
 		log.Fatalf("failed to upsert HTTP responses: %v", err)
 	}
 }

--- a/gidari_example_test.go
+++ b/gidari_example_test.go
@@ -91,7 +91,7 @@ func (w *ExampleWriter) Write(ctx context.Context, list *structpb.ListValue) err
 	return nil
 }
 
-func ExampleHTTPService_Upsert() {
+func ExampleHTTPService_Store() {
 	ctx := context.TODO()
 
 	const api = "https://anapioficeandfire.com/api"
@@ -122,7 +122,7 @@ func ExampleHTTPService_Upsert() {
 	svc.HTTP.RateLimiter(rate.NewLimiter(rate.Every(1*time.Second), 5))
 
 	// Upsert the responses to the database.
-	if err := svc.HTTP.Upsert(ctx); err != nil {
+	if err := svc.HTTP.Store(ctx); err != nil {
 		log.Fatalf("failed to upsert HTTP responses: %v", err)
 	}
 

--- a/http.go
+++ b/http.go
@@ -152,7 +152,7 @@ func bestFitDecodeType(header string) DecodeType {
 	return decodeType
 }
 
-func (svc *HTTPService) upsert(ctx context.Context, jobs chan<- listWriterJob, done <-chan struct{}) error {
+func (svc *HTTPService) store(ctx context.Context, jobs chan<- listWriterJob, done <-chan struct{}) error {
 	for svc.Iterator.Next(ctx) {
 		rsp := svc.Iterator.Current.Response
 
@@ -193,10 +193,10 @@ func (svc *HTTPService) upsert(ctx context.Context, jobs chan<- listWriterJob, d
 	return nil
 }
 
-// Upsert will concurrently make the requests to the client and store the data
+// Store will concurrently make the requests to the client and store the data
 // from the responses in the provided storage. If no storage is provided, then
 // the data will be discarded.
-func (svc *HTTPService) Upsert(ctx context.Context) error {
+func (svc *HTTPService) Store(ctx context.Context) error {
 	reqCount := len(svc.requests)
 
 	// If there are no requests, do nothing.
@@ -226,7 +226,7 @@ func (svc *HTTPService) Upsert(ctx context.Context) error {
 		})
 	}
 
-	if err := svc.upsert(ctx, upsertWorkerJobs, done); err != nil {
+	if err := svc.store(ctx, upsertWorkerJobs, done); err != nil {
 		return fmt.Errorf("failed to upsert data: %w", err)
 	}
 

--- a/http_test.go
+++ b/http_test.go
@@ -246,7 +246,7 @@ func TestIterator(t *testing.T) {
 				}
 
 				for i := 0; i < count; i++ {
-					err := tcase.svc.HTTP.Upsert(context.Background())
+					err := tcase.svc.HTTP.Store(context.Background())
 					if tcase.err != nil && !errors.Is(err, tcase.err) {
 						t.Errorf("expected error %v, got %v", tcase.err, err)
 					}
@@ -328,7 +328,7 @@ func BenchmarkHTTPServiceDo(b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
 		// Execute the service.
-		if err := svc.HTTP.Upsert(context.Background()); err != nil {
+		if err := svc.HTTP.Store(context.Background()); err != nil {
 			b.Fatal(err)
 		}
 	}


### PR DESCRIPTION
Resolves #405 

This pull request renames the "Upsert" method to "Store" to better reflect the general use case of transporting HTTP responses to local storage. While "Upsert" would be appropriate for persisting data to databases, we also persist data to files, and any other type of storage that can be written to using a ListWriter. Therefore, "Store" is a more general and fitting name for the method.